### PR TITLE
according to Litmus API doc, email body should be CDATA field.

### DIFF
--- a/lib/litmus/email_test.rb
+++ b/lib/litmus/email_test.rb
@@ -16,7 +16,9 @@ module Litmus
         unless email.empty?
           test_set.email_source do |email_source|
             email_source.subject email[:subject]
-            email_source.body email[:body]
+            email_source.body do |body|
+              body.cdata! email[:body]
+            end
           end
         end
       end


### PR DESCRIPTION
Email content embedded in request body should be a CDATA field.

According to http://docs.litmus.com/w/page/18056605/Customer%20API%20documentation%3A%20emails%20create

Request:
XML example:

```
<?xml version="1.0"?>
<test_set>
  <applications type="array">
    <application>
      <code>hotmail</code>
    </application>
    <application>
      <code>gmail</code>
    </application>
    <application>
      <code>notes8</code>
    </application>
  </applications>
  <save_defaults>false</save_defaults>
  <use_defaults>false</use_defaults>
  <email_source>
     <body><![CDATA[your-email-html-goes-here]]></body>
     <subject>My test email to Litmus</subject>
  </email_source>
</test_set>
```
